### PR TITLE
Add API endpoint for upcoming events

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AppHttpControllersApi;
+
+use AppHttpControllersController;
+use AppModelsEvent;
+use IlluminateHttpJsonResponse;
+
+class EventController extends Controller
+{
+    /**
+     * Get all upcoming events with full details
+     *
+     * @return JsonResponse
+     */
+    public function upcoming(): JsonResponse
+    {
+        $events = Event::with(['schedule', 'attending'])
+            ->where('end_date', '>=', now())
+            ->orderBy('start_date', 'asc')
+            ->get();
+
+        $response = $events->map(function (Event $event) {
+            return [
+                'id' => $event->id,
+                'name' => $event->name,
+                'start_date' => $event->start_date,
+                'end_date' => $event->end_date,
+                'location' => $event->location,
+                'description' => $event->description,
+                'image_url' => $event->picture_url,
+                'detail_page_url' => route('events.show', ['event' => $event->id]),
+                'attending_players' => $event->attending->map(function ($user) {
+                    return [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                        'email' => $user->email,
+                    ];
+                })->toArray(),
+                'attending_count' => $event->attending_count,
+                'schedule' => $event->schedule->map(function ($schedule) {
+                    return [
+                        'id' => $schedule->id,
+                        'name' => $schedule->name,
+                        'start_date' => $schedule->start_date,
+                        'end_date' => $schedule->end_date,
+                        'description' => $schedule->description,
+                        'location' => $schedule->location,
+                        'time' => $schedule->time,
+                    ];
+                })->toArray(),
+            ];
+        });
+
+        return response()->json([
+            'success' => true,
+            'data' => $response,
+            'count' => $response->count(),
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+
+use IlluminateSupportFacadesRoute;
+
+Route::get('/events/upcoming', [AppHttpControllersApiEventController::class, 'upcoming']);


### PR DESCRIPTION
Add new API route at /api/events/upcoming that returns all upcoming events in JSON format with full details including: event name, start/end dates, location, attending players with details, link to event details page, image URL, description, and schedule (nested). The endpoint is public (no authentication required) and filters for events that have not yet ended.